### PR TITLE
feat: improve histogram buckets asserting error message

### DIFF
--- a/src/Storage/RedisStorage/HistogramRedisStorage.php
+++ b/src/Storage/RedisStorage/HistogramRedisStorage.php
@@ -116,7 +116,7 @@ final class HistogramRedisStorage implements HistogramStorage
                 sprintf(
                     'Buckets with values is empty for [%s] metric with [%s] labels',
                     $keyWithLabels->metricName,
-                    implode(', ', $keyWithLabels->labels)
+                    json_encode($keyWithLabels->labels)
                 )
             );
             $bucketsWithValues = array_map('floatval', $bucketsWithValues);

--- a/src/Storage/RedisStorage/HistogramRedisStorage.php
+++ b/src/Storage/RedisStorage/HistogramRedisStorage.php
@@ -111,7 +111,14 @@ final class HistogramRedisStorage implements HistogramStorage
                 );
             }
 
-            Assert::notEmpty($bucketsWithValues);
+            Assert::notEmpty(
+                $bucketsWithValues,
+                sprintf(
+                    'Buckets with values is empty for [%s] metric with [%s] labels',
+                    $keyWithLabels->metricName,
+                    implode(', ', $keyWithLabels->labels)
+                )
+            );
             $bucketsWithValues = array_map('floatval', $bucketsWithValues);
 
             yield new HistogramMetricValue(

--- a/src/Storage/RedisStorage/HistogramRedisStorage.php
+++ b/src/Storage/RedisStorage/HistogramRedisStorage.php
@@ -114,7 +114,7 @@ final class HistogramRedisStorage implements HistogramStorage
             Assert::notEmpty(
                 $bucketsWithValues,
                 sprintf(
-                    'Buckets with values is empty for [%s] metric with [%s] labels',
+                    'Buckets with values are empty for [%s] metric with [%s] labels',
                     $keyWithLabels->metricName,
                     json_encode($keyWithLabels->labels)
                 )

--- a/src/Storage/RedisStorage/HistogramRedisStorage.php
+++ b/src/Storage/RedisStorage/HistogramRedisStorage.php
@@ -114,9 +114,9 @@ final class HistogramRedisStorage implements HistogramStorage
             Assert::notEmpty(
                 $bucketsWithValues,
                 sprintf(
-                    'Buckets with values are empty for [%s] metric with [%s] labels',
+                    'Buckets with values are empty for [%s] metric with key [%s]',
                     $keyWithLabels->metricName,
-                    json_encode($keyWithLabels->labels)
+                    $this->metricKeySerializer->serialize($keyWithLabels),
                 )
             );
             $bucketsWithValues = array_map('floatval', $bucketsWithValues);


### PR DESCRIPTION
Improve histogram buckets assertion error message for better debugging when error is occurred.

**Old message**
```
Expected a non-empty value. Got: array
```

**New message**
```
Buckets with values are empty for [sample_metrics] with key [sample_metrics|{"a":"b"}]
```